### PR TITLE
Fix issue with [object object] persisted to index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './setup/setup';
+export * from './setup/changes';
 export * from './models';

--- a/src/setup/index.service.ts
+++ b/src/setup/index.service.ts
@@ -36,8 +36,8 @@ export class FireSearchIndexService {
             let values: string = property.split('.').reduce((accumulator, currentProperty) => {
                 return accumulator[currentProperty] || {};
             }, data) || '';
-
-            values = values.toString();
+    
+            values = values = typeof values === 'object' ? JSON.stringify(values) : values.toString();
 
             if (typeof values === 'string') {
                 return values.includes(' ') ? [values].concat(values.split(' ')) : [values];


### PR DESCRIPTION
When upserting key/val when key does not exist in a document, the result is a string "`[object object]`" getting persisted to the index. 

There are a few ways to fix this depending on what the user wants. Once case is the example in this commit that saves the object as a string (instead of the `[object object]` string. 

Alternate solution:
- line 37: ....` || ''` instead of `|| {}`